### PR TITLE
readme: Convert to markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,22 @@ Prerequisites
 
 2. Create a symlink to XULRunner inside this project directory:
 
+   ```
    $ ln -s /path/to/where/you/put/xulrunner xulrunner-sdk
+   ```
 
 3. Fetch the Zotero extension source as a submodule:
 
+   ```
    $ git submodule init
    $ git submodule update
+   ```
 
 4. Clone the Zotero translators repository, too:
 
+   ```
    $ git clone https://github.com/zotero/translators.git
+   ```
 
 Configuration
 =============
@@ -33,22 +39,29 @@ Build and Run
 
 6. Run the build.sh script.  If all goes well, there should be no output.
 
+   ```
    $ ./build.sh
+   ```
 
 7. Run the server:
 
+   ```
    $ build/run_translation-server.sh 
 
    zotero(3)(+0000000): HTTP server listening on *:1969
+   ```
 
 8. Try a query!
 
+   ```
    $ curl -d '{"url":"http://www.tandfonline.com/doi/abs/10.1080/15424060903167229","sessionid":"abc123"}' \
           --header "Content-Type: application/json" \
           localhost:1969/web
+   ```
 
 Endpoints
 =========
 
-Supported endpoints are: /web, /import, /export, and /refresh.
-Read src/server_translations.js for more information.
+Supported endpoints are: `/web`, `/import`, `/export`, and `/refresh`.
+
+Read [server_translation.js](./src/server_translation.js) for more information.


### PR DESCRIPTION
- Add `.md` extension so GitHub recognises it as markdown.
- Add `<pre>` wrappers for the code snippets.
- Backtick endpoints.
- Turn mentioned file names into links to their contents.
- Fix typo in file name (`server_translations.js` -> `server_translation.js`).
