### PR TITLE
Fix for internal 500 errors due to invalid URLs

### DIFF
--- a/src/server_translation.js
+++ b/src/server_translation.js
@@ -158,10 +158,13 @@ Zotero.Server.Translation.Web.prototype = {
 		
 		try {
 			var url = Services.io.newURI(data.url, "UTF-8", null);
-		} catch(e) {}
-		
-		if(!url || (!url.schemeIs("http") && !url.schemeIs("https"))) {
+		} catch(e) {
 			sendResponseCallback(400, "text/plain", "Invalid URL specified\n");
+			return;
+		}
+		
+		if(!url.schemeIs("http") && !url.schemeIs("https")) {
+			sendResponseCallback(400, "text/plain", "Invalid protocol specified\n");
 			return;
 		}
 		


### PR DESCRIPTION
Invalid URLs were causing 500 errors instead
of 400 errors. This was because schemeIs()
was getting called on non-nsiURI objects since
Services.io.newURI was failing silently (was
wrapped inside a try block.) To replicate, query
using a 'URL' with no protocol specified (i.e.
'github.com')

Changes:
Moved 'Invalid URL specified' into catch block
when trying to create a Services.io.newURI

Gives separate message for when protocol is
neither http nor https (still returns 400)
