### PR TITLE
Set translatorsDir to %CurProcD%/../module/zotero/Translators by default

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,4 +1,4 @@
-pref("translation-server.translatorsDirectory", "/Users/simon/Desktop/Development/FS/zotero/translators");
+pref("translation-server.translatorsDirectory", "");
 pref("translation-server.httpServer.port", "1969");
 pref("translation-server.debug.log", true);
 pref("translation-server.debug.time", true);


### PR DESCRIPTION
Since it's recommended to clone the submodules (including translators) recursively, `modules/zotero/translators` will be the right source for the translators in most cases. If users don't configure anything, this should be the default location to look for, not the hard-coded location.
