### PR TITLE
Return bad input error in import endpoint

### DIFF
--- a/src/server_translation.js
+++ b/src/server_translation.js
@@ -347,17 +347,16 @@ Zotero.Server.Translation.Import.prototype = {
 	"supportedMethods":["POST"],
 	
 	"init":function(url, data, sendResponseCallback) {
+		this.sendResponse = sendResponseCallback;
+		
 		if(!data) {
-			res.writeHead(400, "Bad Request", {'Content-Type': 'text/plain'});
-			res.end("No input provided\n");
+			this.sendResponse(400, "text/plain", "No input provided\n");
 			return;
 		}
 		
 		var translate = new Zotero.Translate.Import();
 		translate.noWait = true;
 		translate.setString(data);
-		this.sendResponse = sendResponseCallback;
-		
 		translate.setHandler("translators", this.translators.bind(this));
 		translate.setHandler("done", this.done.bind(this));
 		translate.getTranslators();


### PR DESCRIPTION
If no data is submitted to import, return a 400
bad input error. Previously returned a 500
internal server error as res was undefined.

Addresses issue #41