### PR TITLE
Add a step to the docker-based installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,12 @@ Currently supports import, export, and web translation
 
 ### Docker (recommended)
 
+1. `git clone --recursive https://github.com/zotero/translation-server`
+
+1. `cd translation-server`
+
 1. `docker build -t translation-server -f Dockerfile .`
+
 1. `docker run --rm -p 1969:1969 --name translation-server-container translation-server`
 
 ### Manually


### PR DESCRIPTION
Since it's mentioned in the manual installation guide, it should also be mentioned in the docker-based method, especially to stress out that it requires a recursive checkout.