### PR TITLE
Update steps in the build process in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,11 @@ When you’re done, ensure your changes are applied to `modules/zotero` and `mod
 
 1. `git clone --recursive https://github.com/zotero/translation-server`
 
-1. `cd translation-server`
+1. `cd translation-server/modules/zotero`
+
+1. `npm install && npm run build`
+
+1. `cd ../..`
 
 1. `./fetch_sdk`
 


### PR DESCRIPTION
Include steps to build Zotero in the manual process so that `build.sh` script works as intended