### PR TITLE
Try to use DOI if URL fails and add a domain blacklist

### DIFF
--- a/config.js
+++ b/config.js
@@ -42,3 +42,7 @@ pref("translation-server.httpServer.allowedOrigins", "");
 pref("translation-server.translators.CrossrefREST.email", "");
 // Identifier search endpoint
 pref("translation-server.identifierSearchURL", "");
+
+// Blacklist domains
+pref("translation-server.blacklistedDomains", "");
+


### PR DESCRIPTION
`translation-server.blacklistedDomains` should have a domain list separated with commas i.e. '^domain.com$,^domain2.com$'. But that's not very convenient. Any ideas to make this more convenient?